### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 ---
 name: CI
 
+permissions:
+  contents: read
+
 'on':
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sebdanielsson/ansible-role-cloudflared/security/code-scanning/3](https://github.com/sebdanielsson/ansible-role-cloudflared/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily checks out code and runs tests, it only needs read access to repository contents. We will add the following permissions block at the root level of the workflow:

```yaml
permissions:
  contents: read
```

This ensures that all jobs in the workflow inherit these minimal permissions unless they define their own `permissions` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
