### PR TITLE
Repository migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,9 @@ jobs:
       matrix:
         include:
           - docker_image: debian
-            docker_tag: '12'
-            playbook: converge.yml
-            experimental: false
-
-          - docker_image: debian
             docker_tag: '13'
             playbook: converge.yml
-            experimental: true
+            experimental: false
 
           - docker_image: ubuntu
             docker_tag: '24.04'
@@ -92,7 +87,7 @@ jobs:
       matrix:
         include:
           - docker_image: debian
-            docker_tag: '12'
+            docker_tag: '13'
             experimental: false
 
           - docker_image: ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       matrix:
         include:
           - docker_image: debian
-            docker_tag: '13'
+            docker_tag: '12'  # Latest possible because of migration from flavor-specific to any suite
             experimental: false
 
           - docker_image: ubuntu

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,42 @@ jobs:
           MOLECULE_DOCKER_IMAGE: ${{ matrix.docker_image }}
           MOLECULE_DOCKER_TAG: ${{ matrix.docker_tag }}
           MOLECULE_PLAYBOOK: ${{ matrix.playbook }}
+
+  migration-test:
+    name: Migration Test
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        include:
+          - docker_image: debian
+            docker_tag: '12'
+            experimental: false
+
+          - docker_image: ubuntu
+            docker_tag: '24.04'
+            experimental: false
+
+    steps:
+      - name: Check out the codebase
+        uses: actions/checkout@v5
+        with:
+          path: 'sebdanielsson.cloudflared'
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run Migration Molecule tests
+        run: molecule test -s migration
+        continue-on-error: ${{ matrix.experimental }}
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'
+          MOLECULE_DOCKER_IMAGE: ${{ matrix.docker_image }}
+          MOLECULE_DOCKER_TAG: ${{ matrix.docker_tag }}

--- a/molecule/migration/README.md
+++ b/molecule/migration/README.md
@@ -1,0 +1,37 @@
+# Migration Test
+
+This molecule scenario tests the migration from flavor-specific repositories to the universal `any` suite repository.
+
+## What it tests
+
+1. **Prepare Phase**: Sets up a deprecated flavor-specific cloudflare repository (e.g., `bookworm`, `jammy`, etc.)
+2. **Converge Phase**: Runs the ansible role which should migrate to the `any` suite
+3. **Verify Phase**: Confirms that:
+   - The repository now uses `Suites: any`
+   - The cloudflared package is installable and working
+   - No flavor-specific suite remains in the configuration
+
+## Running the test
+
+```bash
+# Run just the migration test
+molecule test -s migration
+
+# Or use the helper script
+./test-migration.sh
+
+# Run with specific distribution
+MOLECULE_DOCKER_IMAGE=debian MOLECULE_DOCKER_TAG=12 molecule test -s migration
+MOLECULE_DOCKER_IMAGE=ubuntu MOLECULE_DOCKER_TAG=24.04 molecule test -s migration
+```
+
+## Test Flow
+
+```mermaid
+graph LR
+    A[Prepare<br/>Create old<br/>flavor repo] --> B[Converge<br/>Run role<br/>migration]
+    B --> C[Verify<br/>Check new<br/>any suite]
+    C --> D[Cleanup<br/>Destroy<br/>container]
+```
+
+This ensures that users with existing flavor-specific repositories will be seamlessly migrated to the new universal `any` suite.

--- a/molecule/migration/converge.yml
+++ b/molecule/migration/converge.yml
@@ -1,0 +1,7 @@
+---
+- name: Converge - Test migration from flavor-specific to any suite
+  hosts: all
+  become: true
+  roles:
+    - role: sebdanielsson.cloudflared
+      state: present  # noqa: var-naming[no-role-prefix]

--- a/molecule/migration/molecule.yml
+++ b/molecule/migration/molecule.yml
@@ -1,0 +1,23 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+
+driver:
+  name: docker
+
+platforms:
+  - name: instance
+    image: ${MOLECULE_DOCKER_IMAGE:-ubuntu}:${MOLECULE_DOCKER_TAG:-latest}
+    cgroupns_mode: host
+
+provisioner:
+  name: ansible
+  playbooks:
+    converge: converge.yml
+    prepare: prepare.yml
+    verify: verify.yml
+
+verifier:
+  name: ansible

--- a/molecule/migration/prepare.yml
+++ b/molecule/migration/prepare.yml
@@ -1,0 +1,39 @@
+---
+- name: Prepare - Setup deprecated flavor-specific repository
+  hosts: all
+  become: true
+  tasks:
+    - name: Install required packages
+      ansible.builtin.apt:
+        name: 
+          - python3-debian
+          - gnupg
+        update_cache: true
+        state: present
+
+    - name: Create deprecated cloudflare repository (flavor-specific)
+      ansible.builtin.deb822_repository:
+        name: cloudflare
+        types: deb
+        uris: https://pkg.cloudflare.com/cloudflared
+        suites: "{{ ansible_distribution_release }}"
+        components: main
+        signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
+        state: present
+
+    - name: Verify deprecated repository is created with flavor-specific suite
+      ansible.builtin.slurp:
+        path: "/etc/apt/sources.list.d/cloudflare.sources"
+      register: deprecated_repo
+
+    - name: Debug deprecated repository content
+      ansible.builtin.debug:
+        msg: "Deprecated repo contains: {{ deprecated_repo.content | b64decode }}"
+
+    - name: Assert deprecated repository uses distribution-specific suite
+      ansible.builtin.assert:
+        that:
+          - '"Suites: any" not in (deprecated_repo.content | b64decode)'
+          - 'ansible_distribution_release in (deprecated_repo.content | b64decode)'
+        fail_msg: "Deprecated repository was not set up correctly"
+        success_msg: "Deprecated repository with flavor-specific suite created successfully"

--- a/molecule/migration/prepare.yml
+++ b/molecule/migration/prepare.yml
@@ -5,7 +5,7 @@
   tasks:
     - name: Install required packages
       ansible.builtin.apt:
-        name: 
+        name:
           - python3-debian
           - gnupg
         update_cache: true

--- a/molecule/migration/requirements.yml
+++ b/molecule/migration/requirements.yml
@@ -1,0 +1,10 @@
+---
+collections:
+  - name: community.general
+    version: 11.2.1
+
+  - name: ansible.posix
+    version: 2.1.0
+
+  - name: community.docker
+    version: 4.7.0

--- a/molecule/migration/verify.yml
+++ b/molecule/migration/verify.yml
@@ -1,0 +1,54 @@
+---
+- name: Verify - Migration to 'any' suite successful
+  hosts: all
+  become: true
+  tasks:
+    - name: Check that cloudflare repository file exists
+      ansible.builtin.stat:
+        path: "/etc/apt/sources.list.d/cloudflare.sources"
+      register: cloudflare_sources
+
+    - name: Read cloudflare repository content
+      ansible.builtin.slurp:
+        path: "/etc/apt/sources.list.d/cloudflare.sources"
+      register: cloudflare_repo
+      when: cloudflare_sources.stat.exists
+
+    - name: Debug repository content after migration
+      ansible.builtin.debug:
+        msg: "Repository content: {{ cloudflare_repo.content | b64decode }}"
+      when: cloudflare_sources.stat.exists
+
+    - name: Verify repository now uses 'any' suite
+      ansible.builtin.assert:
+        that:
+          - cloudflare_sources.stat.exists
+          - '"Suites: any" in (cloudflare_repo.content | b64decode)'
+          - '"https://pkg.cloudflare.com/cloudflared" in (cloudflare_repo.content | b64decode)'
+          - '"Components: main" in (cloudflare_repo.content | b64decode)'
+        fail_msg: "Repository migration failed - does not contain 'Suites: any'"
+        success_msg: "Repository successfully migrated to use 'any' suite"
+
+    - name: Verify cloudflared package is installable
+      ansible.builtin.apt:
+        name: cloudflared
+        state: present
+        update_cache: true
+
+    - name: Verify cloudflared is installed
+      ansible.builtin.command:
+        cmd: cloudflared --version
+      register: cloudflared_version
+      changed_when: false
+
+    - name: Debug cloudflared version
+      ansible.builtin.debug:
+        msg: "Cloudflared version: {{ cloudflared_version.stdout }}"
+
+    - name: Verify cloudflared version output is not empty
+      ansible.builtin.assert:
+        that:
+          - cloudflared_version.stdout is defined
+          - cloudflared_version.stdout | length > 0
+        fail_msg: "Cloudflared is not properly installed"
+        success_msg: "Cloudflared is successfully installed and working"

--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -6,17 +6,16 @@
     update_cache: true
     state: present
 
-- name: Add cloudflared repository for Debian 13 (experimental)
+- name: Remove deprecated flavor-specific cloudflared repository
   become: true
   ansible.builtin.deb822_repository:
     name: cloudflare
     types: deb
     uris: https://pkg.cloudflare.com/cloudflared
-    suites: any
+    suites: "{{ ansible_distribution_release }}"
     components: main
     signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
-    state: present
-  when: ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] is version('13', '>=')
+    state: absent
 
 - name: Add cloudflared repository
   become: true
@@ -24,7 +23,7 @@
     name: cloudflare
     types: deb
     uris: https://pkg.cloudflare.com/cloudflared
-    suites: '{{ ansible_distribution_release }}'
+    suites: any
     components: main
     signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
     state: present

--- a/tasks/apt/install.yml
+++ b/tasks/apt/install.yml
@@ -6,16 +6,21 @@
     update_cache: true
     state: present
 
-- name: Remove deprecated flavor-specific cloudflared repository
+- name: Check if cloudflare repository exists but is not using 'any' suite
   become: true
-  ansible.builtin.deb822_repository:
-    name: cloudflare
-    types: deb
-    uris: https://pkg.cloudflare.com/cloudflared
-    suites: "{{ ansible_distribution_release }}"
-    components: main
-    signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
+  ansible.builtin.slurp:
+    path: "/etc/apt/sources.list.d/cloudflare.sources"
+  register: cloudflare_repo_content
+  failed_when: false
+
+- name: Remove deprecated cloudflare repository (not using 'any' suite)
+  become: true
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/cloudflare.sources"
     state: absent
+  when:
+    - cloudflare_repo_content.content is defined
+    - '"Suites: any" not in (cloudflare_repo_content.content | b64decode)'
 
 - name: Add cloudflared repository
   become: true

--- a/tasks/apt/uninstall.yml
+++ b/tasks/apt/uninstall.yml
@@ -17,13 +17,18 @@
     signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
     state: absent
 
-- name: Remove deprecated flavor-specific cloudflared repository
+- name: Check if cloudflare repository exists but is not using 'any' suite
   become: true
-  ansible.builtin.deb822_repository:
-    name: cloudflare
-    types: deb
-    uris: https://pkg.cloudflare.com/cloudflared
-    suites: "{{ ansible_distribution_release }}"
-    components: main
-    signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
+  ansible.builtin.slurp:
+    path: "/etc/apt/sources.list.d/cloudflare.sources"
+  register: cloudflare_repo_content
+  failed_when: false
+
+- name: Remove deprecated cloudflare repository (not using 'any' suite)
+  become: true
+  ansible.builtin.file:
+    path: "/etc/apt/sources.list.d/cloudflare.sources"
     state: absent
+  when:
+    - cloudflare_repo_content.content is defined
+    - '"Suites: any" not in (cloudflare_repo_content.content | b64decode)'

--- a/tasks/apt/uninstall.yml
+++ b/tasks/apt/uninstall.yml
@@ -9,22 +9,21 @@
 - name: Remove cloudflared repository
   become: true
   ansible.builtin.deb822_repository:
-    name: cloudflared
-    types: deb
-    uris: https://pkg.cloudflare.com/cloudflared
-    suites: '{{ ansible_distribution_release }}'
-    components: main
-    signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
-    state: absent
-
-- name: Remove cloudflared repository for Debian 13 (experimental)
-  become: true
-  ansible.builtin.deb822_repository:
-    name: cloudflared
+    name: cloudflare
     types: deb
     uris: https://pkg.cloudflare.com/cloudflared
     suites: any
     components: main
     signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
     state: absent
-  when: ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version'] is version('13', '>=')
+
+- name: Remove deprecated flavor-specific cloudflared repository
+  become: true
+  ansible.builtin.deb822_repository:
+    name: cloudflare
+    types: deb
+    uris: https://pkg.cloudflare.com/cloudflared
+    suites: "{{ ansible_distribution_release }}"
+    components: main
+    signed_by: https://pkg.cloudflare.com/cloudflare-main.gpg
+    state: absent


### PR DESCRIPTION
This role now uses Cloudflare's universal `any` suite repository instead of distribution-specific flavor repositories. The role automatically:

- Removes any existing flavor-specific repositories (e.g., `bookworm`, `jammy`, etc.)
- Installs the new universal `any` suite repository
- Ensures seamless migration without user intervention